### PR TITLE
Turn honeycomb queries into browser URLs

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,6 +22,7 @@ func NewRootCmd() *cobra.Command {
 	rootCmd.AddCommand(NewConfigCmd())
 	rootCmd.AddCommand(NewNLToQuery())
 	rootCmd.AddCommand(NewCreateQuery())
+	rootCmd.AddCommand(NewQueryToURL())
 	rootCmd.AddCommand(NewVersionCmd("hccli", os.Stdout))
 	return rootCmd
 }

--- a/cmd/tourl.go
+++ b/cmd/tourl.go
@@ -1,0 +1,78 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/go-logr/zapr"
+	"github.com/jlewi/hccli/pkg"
+	"github.com/jlewi/hccli/pkg/app"
+	"github.com/jlewi/hydros/pkg/util"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+	"os"
+)
+
+// NewQueryToURL creates a command to turn queries into URLs
+func NewQueryToURL() *cobra.Command {
+	var dataset string
+	var query string
+	var queryFile string
+	var baseURL string
+	cmd := &cobra.Command{
+		Use: "querytourl",
+		Run: func(cmd *cobra.Command, args []string) {
+			err := func() error {
+				app := app.NewApp()
+				if err := app.LoadConfig(cmd); err != nil {
+					return err
+				}
+				if err := app.SetupLogging(); err != nil {
+					return err
+				}
+
+				log := zapr.NewLogger(zap.L())
+				logVersion()
+
+				if (query == "" && queryFile == "") || (query != "" && queryFile != "") {
+					return errors.New("Exactly one of --query and --query-file must be specified")
+				}
+
+				if queryFile != "" {
+					data, err := os.ReadFile(queryFile)
+					if err != nil {
+						return errors.Wrapf(err, "Error reading query file %v", queryFile)
+					}
+					query = string(data)
+				}
+
+				hcq := &pkg.HoneycombQuery{}
+
+				if err := json.Unmarshal([]byte(query), hcq); err != nil {
+					log.Error(err, "Error unmarshalling query", "query", query)
+					return errors.Wrapf(err, "Error unmarshalling query")
+				}
+
+				hc, err := pkg.QueryToURL(*hcq, baseURL, dataset)
+				if err != nil {
+					return err
+				}
+				fmt.Printf("Honeycomb URL:\n%v\n", hc)
+
+				return nil
+			}()
+
+			if err != nil {
+				fmt.Printf("Error running request;\n %+v\n", err)
+				os.Exit(1)
+			}
+		},
+	}
+
+	cmd.Flags().StringVarP(&query, "query", "", "", "The honeycomb query")
+	cmd.Flags().StringVarP(&queryFile, "query-file", "", "", "A file containing the honeycomb query")
+	cmd.Flags().StringVarP(&dataset, "dataset", "", "", "The dataset slug to create the query in")
+	cmd.Flags().StringVarP(&baseURL, "base-url", "", "", "The base URL for your honeycomb URLs. It should be something like https://ui.honeycomb.io/${ORG}/environments/${ENVIRONMENT}")
+	util.IgnoreError(cmd.MarkFlagRequired("dataset"))
+	return cmd
+}

--- a/cmd/tourl.go
+++ b/cmd/tourl.go
@@ -3,14 +3,16 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+
 	"github.com/go-logr/zapr"
 	"github.com/jlewi/hccli/pkg"
 	"github.com/jlewi/hccli/pkg/app"
 	"github.com/jlewi/hydros/pkg/util"
+	"github.com/pkg/browser"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
-	"os"
 )
 
 // NewQueryToURL creates a command to turn queries into URLs
@@ -19,6 +21,7 @@ func NewQueryToURL() *cobra.Command {
 	var query string
 	var queryFile string
 	var baseURL string
+	var open bool
 	cmd := &cobra.Command{
 		Use: "querytourl",
 		Run: func(cmd *cobra.Command, args []string) {
@@ -58,7 +61,11 @@ func NewQueryToURL() *cobra.Command {
 					return err
 				}
 				fmt.Printf("Honeycomb URL:\n%v\n", hc)
-
+				if open {
+					if err := browser.OpenURL(hc); err != nil {
+						return errors.Wrapf(err, "Error opening URL %v", hc)
+					}
+				}
 				return nil
 			}()
 
@@ -73,6 +80,7 @@ func NewQueryToURL() *cobra.Command {
 	cmd.Flags().StringVarP(&queryFile, "query-file", "", "", "A file containing the honeycomb query")
 	cmd.Flags().StringVarP(&dataset, "dataset", "", "", "The dataset slug to create the query in")
 	cmd.Flags().StringVarP(&baseURL, "base-url", "", "", "The base URL for your honeycomb URLs. It should be something like https://ui.honeycomb.io/${ORG}/environments/${ENVIRONMENT}")
+	cmd.Flags().BoolVarP(&open, "open", "", false, "Open the URL in a browser")
 	util.IgnoreError(cmd.MarkFlagRequired("dataset"))
 	return cmd
 }

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/go-logr/zapr v1.3.0
 	github.com/google/go-cmp v0.6.0
 	github.com/jlewi/hydros v0.0.5
+	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/pkg/errors v0.9.1
 	github.com/replicate/replicate-go v0.18.1
 	github.com/spf13/cobra v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -128,6 +128,8 @@ github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 h1:n6/
 github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00/go.mod h1:Pm3mSP3c5uWn86xMLZ5Sa7JB9GsEZySvHYXCTK4E9q4=
 github.com/pelletier/go-toml/v2 v2.1.0 h1:FnwAJ4oYMvbT/34k9zzHuZNrhlz48GB3/s6at6/MHO4=
 github.com/pelletier/go-toml/v2 v2.1.0/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdUvyaeZurnPPDc=
+github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 h1:KoWmjvw+nsYOo29YJK9vDA65RGE3NrOnUtO7a+RF9HU=
+github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8/go.mod h1:HKlIX3XHQyzLZPlr7++PzdhaXEj94dEiJgZDTsxEqUI=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -228,6 +230,7 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210616045830-e2b7044e8c71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
 golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/pkg/honeycomb.go
+++ b/pkg/honeycomb.go
@@ -102,8 +102,7 @@ type HoneycombQuery struct {
 	Filters []struct {
 		Op     string      `json:"op,omitempty"`
 		Column interface{} `json:"column,omitempty"`
-		Value  *struct {
-		} `json:"value,omitempty"`
+		Value  string      `json:"value,omitempty"`
 	} `json:"filters"`
 	FilterCombination string `json:"filter_combination,omitempty"`
 	Granularity       int    `json:"granularity,omitempty"`

--- a/pkg/replicate.go
+++ b/pkg/replicate.go
@@ -2,13 +2,14 @@ package pkg
 
 import (
 	"context"
+	"strings"
+
 	"github.com/go-logr/zapr"
 	"github.com/jlewi/hccli/pkg/config"
 	"github.com/jlewi/hydros/pkg/files"
 	"github.com/pkg/errors"
 	"github.com/replicate/replicate-go"
 	"go.uber.org/zap"
-	"strings"
 )
 
 // ReplicateClient is a client for the model when deployed on Replicate (as opposed to K8s)

--- a/pkg/replicate_test.go
+++ b/pkg/replicate_test.go
@@ -2,10 +2,11 @@ package pkg
 
 import (
 	"encoding/json"
-	"github.com/jlewi/hccli/pkg/config"
-	"go.uber.org/zap"
 	"os"
 	"testing"
+
+	"github.com/jlewi/hccli/pkg/config"
+	"go.uber.org/zap"
 )
 
 func Test_Replicate(t *testing.T) {

--- a/pkg/urls.go
+++ b/pkg/urls.go
@@ -2,6 +2,7 @@ package pkg
 
 import (
 	"encoding/json"
+
 	"github.com/pkg/errors"
 )
 

--- a/pkg/urls.go
+++ b/pkg/urls.go
@@ -1,0 +1,18 @@
+package pkg
+
+import (
+	"encoding/json"
+	"github.com/pkg/errors"
+)
+
+// QueryToURL converts a query to a URL.
+// It uses Honeycomb's query parameter and template links feature
+// https://docs.honeycomb.io/investigate/collaborate/share-query/
+func QueryToURL(query HoneycombQuery, baseURL string, dataset string) (string, error) {
+	b, err := json.Marshal(query)
+	if err != nil {
+		return "", errors.Wrapf(err, "Failed to serialize query to JSON")
+	}
+
+	return baseURL + "/datasets/" + dataset + "?query=" + string(b), nil
+}


### PR DESCRIPTION
Honeycomb lets you specify the query directly in the URL
https://docs.honeycomb.io/investigate/collaborate/share-query/#the-query-parameter

This adds a CLI command to turn the query into a URL and optionally open it in the browser.